### PR TITLE
Graph databases: Add JanusGraph project

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ Any contribution is welcome!
 * [Cayley](https://github.com/cayleygraph/cayley)
 * [Neo4j](https://github.com/neo4j)
 * [OrientDB](https://orientdb.com)
+* [JanusGraph](https://github.com/JanusGraph/janusgraph)
 
 ### Relational
 


### PR DESCRIPTION
**[JanusGraph](http://janusgraph.org/)** is a state-of-the-art, highly scalable, available, efficient, replicated, distributed graph database solution [supported by The Linux Foundation since 2017](https://www.linuxfoundation.org/blog/2017/01/the-linux-foundation-welcomes-janusgraph/) that has received contributions from Google, Amazon, IBM and others. (Fun fact: It was initially based out of [the _Titan_ graph database project](http://titan.thinkaurelius.com/).)
