### PR TITLE
Add mamba project (conda drop-in replacement)

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ of bidirectional reflectance distribution functions
 
 * [conda](https://github.com/conda/conda)
 * [Ecosystem](https://github.com/PeregrineLabs/Ecosystem)
+* [mamba](https://github.com/mamba-org/mamba) - a faster drop-in replacement for "conda"
 * [qip](https://github.com/themill/qip) - Quarantined Installer for Python
 * [Rez](https://github.com/nerdvegas/rez)
 * [Rez Packages](https://github.com/predat/rez-packages)


### PR DESCRIPTION
Hello! 👋

https://github.com/mamba-org/mamba is a 1:1 replacement for conda but they refactored the slow bits with C so it's wayyyy faster.

They also have a `miniconda` equivalent called `micromamba` that is statically compiled and unlike miniconda, does not require Python to exist... very cool!

It does not stop there though; the mamba devs also have a conda-compatible private package server project: https://github.com/mamba-org/quetz
which is pretty great as the conda creators never opensourced an official one (probably because they make money selling people on [Anaconda Cloud](https://www.anaconda.com/pricing).)
