### PR TITLE
Add 3DPro to Communities

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,7 @@ Not really efficient, you can find more links on the sys admin awesome list ; [o
 ## Communities
 
 * [3DVF](http://3dvf.com)
+* [3DPro](https://3dpro.org)
 * [Blender Discord (French)](https://discordapp.com/channels/168826665307209728/168826665307209728)
 * [CGWire Discord](https://discord.com/invite/VbCxtKN)
 * [Houdini Discord](https://discordapp.com/channels/230123485668573184/360768996980555776)


### PR DESCRIPTION
https://3dpro.org/ is an industry community and mailing list discussion group that's been around since 1998. It is the oldest of the vfx/cgi communities to my knowledge.

They also have a Discord server for members, although it's not very active compared to the mailing list itself. (You can find me on both, hehe. 👋)
