### PR TITLE
Add A-Frame WebXR web framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Any contribution is welcome!
 
 ### 3D realtime engines
 
+* [A-Frame](https://aframe.io/) - An easy web framework for building 3D/AR/VR experiences.
 * [Armory](https://armory3d.org) - 3D engine with Blender integration focused on portability, minimal footprint and performance
 * [Babylon.js](http://www.babylonjs.com/) - WebGL engine
 * [Bevy](https://bevyengine.org/) - A refreshingly simple data-driven game engine built in Rust


### PR DESCRIPTION
Nice web framework for building VR and AR experiences that run on your phone or any mainstream WebXR-friendly browser.

For example, if you browse with the Oculus Browser you can enter the website in VR. It's pretty wild!
