### PR TITLE
Update OpenPype to Ayon

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,7 +385,7 @@ Any contribution is welcome!
 * [Avalon](https://getavalon.github.io)
 * [Damas](http://damas-software.org/)
 * [Kabaret](https://www.kabaretstudio.com/)
-* [OpenPype](https://openpype.io)
+* [Ayon](https://ynput.io/)
 * [Plex](https://github.com/richteralexander/plex)
 * [Prism](https://prism-pipeline.com/)
 * [SnowFS](https://github.com/Snowtrack/SnowFS)

--- a/README.md
+++ b/README.md
@@ -383,9 +383,9 @@ Any contribution is welcome!
 ## Asset managers
 
 * [Avalon](https://getavalon.github.io)
+* [Ayon](https://ynput.io/)
 * [Damas](http://damas-software.org/)
 * [Kabaret](https://www.kabaretstudio.com/)
-* [Ayon](https://ynput.io/)
 * [Plex](https://github.com/richteralexander/plex)
 * [Prism](https://prism-pipeline.com/)
 * [SnowFS](https://github.com/Snowtrack/SnowFS)


### PR DESCRIPTION
OpenPype have bin renamed to Ayon a while ago. This PR updates that in the list.
Ayon is now also a production manager. Should it be double added, moved or stay where it is?