### PR TITLE
remove SnowFS/Snowtrack

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,7 +394,6 @@ Any contribution is welcome!
 * [Kabaret](https://www.kabaretstudio.com/)
 * [Plex](https://github.com/richteralexander/plex)
 * [Prism](https://prism-pipeline.com/)
-* [SnowFS](https://github.com/Snowtrack/SnowFS)
 * [TACTIC-Handler](https://github.com/listyque/TACTIC-Handler)
 * [Tik Manager](https://tik-manager.com) - Artist-friendly asset and pipeline manager.
 


### PR DESCRIPTION
Perforce acquired Snowtrack and rebranded it P4 One. I believe the new product is closed source. https://www.perforce.com/press-releases/announcing-p4-one

original URL is offline.
https://github.com/Snowtrack/SnowFS