### PR TITLE
Add CozyClay to DCCs > 3D

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Any contribution is welcome!
 * [Threestudio](https://github.com/threestudio-project/threestudio) - A unified framework for 3D content generation.
 * [Material Maker](https://rodzilla.itch.io/material-maker) - A procedural materials authoring tool based on the Godot Engine.
 * [Mesh2Motion](https://mesh2motion.org/) - FREE & open-source web application to animate your 3D models. Supports humanoid, four-legged, and bird creatures.
+* [CozyClay](https://cozyclay.org) - Open-source browser-based 3D staging and previz studio. Block a scene, pose characters, author camera moves and cuts on a timeline, and preview generated motion. Handles like the Unity Editor.
 
 ### 3D realtime engines
 


### PR DESCRIPTION
[CozyClay](https://cozyclay.org) is an open-source (GPL-3.0) browser-based 3D staging and previz studio built with Three.js and React Three Fiber.

It covers the previz/layout step: block a scene with primitives and set pieces, pose characters, draw root paths, author camera moves and cuts on a resizable timeline, and preview generated motion with sparse IK correction. Camera and gizmo controls follow Unity Editor conventions, so it is quick to pick up for anyone coming from a DCC.

Added next to Mesh2Motion, since both are browser-based 3D authoring tools in that section.

- Repo: https://github.com/HaD0Yun/CozyClay
- Runs locally with `npx cozyclay`